### PR TITLE
DPE-443: Fix Jetty wrapper configuration at startup

### DIFF
--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
@@ -370,9 +370,10 @@ class JettyServerWrapper implements BatchVisitor {
 			// PAXWEB-1112: TCCL to perform static initialization of XmlConfiguration with proper TCCL
 			// needed for org.eclipse.jetty.xml.XmlConfiguration.__factoryLoader
 			Thread.currentThread().setContextClassLoader(jettyXmlCl);
-			try (InputStream inStream = getClass().getResourceAsStream("/jetty-empty.xml")) {
+			String emptyConfigFile = "jetty-empty.xml";
+			try (InputStream inStream = getClass().getResourceAsStream("/" + emptyConfigFile)) {
 				if (inStream != null) {
-					Path emptyConfig = Files.createTempFile("jetty-empty", ".tmp");
+					Path emptyConfig = Files.createTempFile(emptyConfigFile, ".tmp");
 					try (FileOutputStream outStream = new FileOutputStream(new File(emptyConfig.toUri()))) {
 						inStream.transferTo(outStream);
 						new XmlConfiguration(jettyFactory.newResource(emptyConfig.toUri().toURL()));

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
@@ -378,6 +378,8 @@ class JettyServerWrapper implements BatchVisitor {
 						inStream.transferTo(outStream);
 						new XmlConfiguration(jettyFactory.newResource(emptyConfig.toUri().toURL()));
 					} finally {
+						// the tmp file can be safely deleted as it was only used to initialize XmlConfiguration,
+						// and no actual configuration will be applied from it
 						Files.delete(emptyConfig);
 					}
 				}

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
@@ -372,7 +372,7 @@ class JettyServerWrapper implements BatchVisitor {
 			Thread.currentThread().setContextClassLoader(jettyXmlCl);
 			try (InputStream inStream = getClass().getResourceAsStream("/jetty-empty.xml")) {
 				if (inStream != null) {
-					Path emptyConfig = Files.createTempFile(getClass().getName(), ".tmp");
+					Path emptyConfig = Files.createTempFile("jetty-empty", ".tmp");
 					try (FileOutputStream outStream = new FileOutputStream(new File(emptyConfig.toUri()))) {
 						inStream.transferTo(outStream);
 						new XmlConfiguration(jettyFactory.newResource(emptyConfig.toUri().toURL()));

--- a/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
+++ b/pax-web-jetty/src/main/java/org/ops4j/pax/web/service/jetty/internal/JettyServerWrapper.java
@@ -127,7 +127,6 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;


### PR DESCRIPTION
🏁 **Context**
- [DPE-443](https://qlik-dev.atlassian.net/browse/DPE-443)

🔍 **What is the problem this PR is trying to solve?**
Fix Jetty wrapper configuration at startup.  

🚀 **What is the chosen solution to this problem?**

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-369]: https://qlik-dev.atlassian.net/browse/DPE-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DPE-436]: https://qlik-dev.atlassian.net/browse/DPE-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DPE-443]: https://qlik-dev.atlassian.net/browse/DPE-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ