### PR TITLE
DPE-675: add fragment bundle for JSON-P Javax (Glassfish) 

### DIFF
--- a/pax-web-fragments/pax-web-fragment-jsonp-javax-glassfish/pom.xml
+++ b/pax-web-fragments/pax-web-fragment-jsonp-javax-glassfish/pom.xml
@@ -31,10 +31,10 @@
 	<artifactId>pax-web-fragment-jsonp-javax-glassfish</artifactId>
 	<packaging>bundle</packaging>
 
-	<name>OPS4J Pax Web - JSON-P Javax (glassfish) with SPI-FLY requirements</name>
+	<name>OPS4J Pax Web - JSON-P Javax (GlassFish) providing JavaJSONP capability</name>
 
 	<description>
-		This fragment adds SPI-FLY requirements for org.apache.johnzon:johnzon-core.
+		This fragment adds SPI-FLY requirements for org.apache.johnzon/johnzon-core
 	</description>
 
 	<build>

--- a/pax-web-fragments/pax-web-fragment-jsonp-javax-glassfish/pom.xml
+++ b/pax-web-fragments/pax-web-fragment-jsonp-javax-glassfish/pom.xml
@@ -21,34 +21,39 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.ops4j.pax</groupId>
-		<artifactId>web</artifactId>
+		<groupId>org.ops4j.pax.web</groupId>
+		<artifactId>pax-web-fragments</artifactId>
 		<version>9.99.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<groupId>org.ops4j.pax.web</groupId>
-	<artifactId>pax-web-fragments</artifactId>
-	<packaging>pom</packaging>
+	<artifactId>pax-web-fragment-jsonp-javax-glassfish</artifactId>
+	<packaging>bundle</packaging>
 
-	<name>OPS4J Pax Web - support bundles</name>
+	<name>OPS4J Pax Web - JSON-P Javax (glassfish) with SPI-FLY requirements</name>
 
-	<modules>
-		<!--
-			These are fragments that either export older versions of some packages or add osgi.contracts to
-			JakartaEE _canonical_ API jars
-		-->
-		<module>pax-web-compatibility-cdi12</module>
-		<module>pax-web-compatibility-servlet31</module>
-		<module>pax-web-compatibility-el2</module>
-		<module>pax-web-compatibility-interceptor12</module>
-		<module>pax-web-compatibility-annotation13</module>
-		<module>pax-web-compatibility-jpa2</module>
-		<module>pax-web-compatibility-jaxrs2</module>
-		<!-- These are other support fragments -->
-		<module>pax-web-fragment-jsonp-javax-glassfish</module>
-		<module>pax-web-fragment-myfaces-inject</module>
-		<module>pax-web-fragment-myfaces-spifly</module>
-	</modules>
+	<description>
+		This fragment adds SPI-FLY requirements for org.apache.johnzon:johnzon-core.
+	</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Fragment-Host>org.glassfish.javax.json</Fragment-Host>
+						<Provide-Capability><![CDATA[
+							osgi.contract;osgi.contract=JavaJSONP;uses:="javax.json,javax.json.spi,javax.json.stream";
+							version:List<Version>="1.1,1.0"
+						]]></Provide-Capability>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>


### PR DESCRIPTION
🏁 **Context**
- [DPE-675](https://qlik-dev.atlassian.net/browse/DPE-675)

🔍 **What is the problem this PR is trying to solve?**
Karaf `4.4.6` is not compatible with Decanter `2.9.0`/`2.10.0` due to conflicts in the Export-Package of the following bundles:
`org.apache.sling/org.apache.sling.commons.johnzon/1.2.16`
```
Export-Package =
        javax.json;uses:=javax.json.stream;version=1.1,
        javax.json.spi;uses:="javax.json,javax.json.stream";version=1.1,
        javax.json.stream;uses:=javax.json;version=1.1,
        org.apache.johnzon.core;uses:="javax.json,javax.json.spi,javax.json.stream,org.apache.johnzon.core.spi";version=1.2.21,
        org.apache.johnzon.core.io;version=1.2.21,
        org.apache.johnzon.core.spi;uses:="javax.json,javax.json.spi";version=1.2.21,
        org.apache.johnzon.core.util;version=1.2.21
```
`mvn:org.glassfish/javax.json/1.1.4`
```
Export-Package =
        javax.json;uses:=javax.json.stream;version=1.1.4,
        javax.json.spi;uses:="javax.json,javax.json.stream";version=1.1.4,
        javax.json.stream;uses:=javax.json;version=1.1.4,
        org.glassfish.json.api;version=1.1.4
```
When the Decanter features are installed, unnecessary bundles are refreshed, which causes service references to be lost, for instance, the `org.apache.karaf.decanter.api.marshaller.Marshaller` service reference in `org.apache.karaf.decanter.appender.log.LogAppender`.

🚀 **What is the chosen solution to this problem?**
In Karaf framework features migrate from `org.apache.sling/org.apache.sling.commons.johnzon` to `org.glassfish/javax.json` (and a fragmet bundle for SPI-FLY) + `org.apache.johnzon/johnzon-core`. 
For this migration to work, the SPI-FLY requirements for org.apache.johnzon:johnzon-core must be satisfied:
```
Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.service
 loader.registrar)",osgi.contract;osgi.contract=JavaJSONP;filter:="(&(
 osgi.contract=JavaJSONP)(version=1.1.0))",osgi.ee;filter:="(&(osgi.ee
 =JavaSE)(version=1.8))"
```

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-675]: https://qlik-dev.atlassian.net/browse/DPE-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ